### PR TITLE
v0.3.8: wasm32 runtime-agnostic timeout for Peer::initiate_handshake

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bsv-rs"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 description = "BSV blockchain SDK for Rust - primitives, script, transactions, and more"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,9 @@ futures-util = { version = "0.3", optional = true }
 # Async futures (for overlay module parallel operations)
 futures = "0.3"
 
+# Runtime-agnostic timer (wasm32 only — CF Workers have no tokio time-driver)
+futures-timer = { version = "3", optional = true }
+
 # URL encoding (for storage module)
 urlencoding = "2.1"
 
@@ -95,7 +98,7 @@ storage = ["overlay"]
 registry = ["overlay"]
 kvstore = ["overlay"]
 identity = ["auth", "overlay"]
-wasm = ["getrandom/js"]
+wasm = ["getrandom/js", "dep:futures-timer"]
 full = ["primitives", "script", "transaction", "wallet", "messages", "compat", "totp", "auth", "overlay", "storage", "registry", "kvstore", "identity"]
 http = ["dep:reqwest"]
 websocket = ["auth", "dep:tokio-tungstenite", "dep:futures-util"]

--- a/src/auth/peer.rs
+++ b/src/auth/peer.rs
@@ -22,9 +22,49 @@ use crate::wallet::{
 use crate::{Error, Result};
 use rand::RngCore;
 use std::collections::HashMap;
+use std::future::Future;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::{oneshot, RwLock};
+
+/// Wait for `future` to complete, or time out after `timeout_ms` milliseconds.
+///
+/// On native targets this delegates to `tokio::time::timeout`, which requires
+/// a Tokio runtime with the `time` driver enabled. On `wasm32-unknown-unknown`
+/// (with the `wasm` feature enabled) it instead races the future against a
+/// `futures_timer::Delay`, which has no runtime dependency and therefore works
+/// inside Cloudflare Workers, browser `wasm-bindgen-futures` executors, and
+/// other JS-async-style environments that do not provide a Tokio time driver.
+///
+/// A timeout is reported as `Error::AuthError("Handshake timeout".into())` so
+/// the existing call-site error semantics are preserved.
+#[cfg(not(all(target_arch = "wasm32", feature = "wasm")))]
+async fn wait_with_timeout<F>(future: F, timeout_ms: u64) -> Result<F::Output>
+where
+    F: Future,
+{
+    tokio::time::timeout(Duration::from_millis(timeout_ms), future)
+        .await
+        .map_err(|_| Error::AuthError("Handshake timeout".into()))
+}
+
+#[cfg(all(target_arch = "wasm32", feature = "wasm"))]
+async fn wait_with_timeout<F>(future: F, timeout_ms: u64) -> Result<F::Output>
+where
+    F: Future,
+{
+    use futures::future::{select, Either};
+    use futures::pin_mut;
+
+    let delay = futures_timer::Delay::new(Duration::from_millis(timeout_ms));
+    pin_mut!(future);
+    pin_mut!(delay);
+    match select(future, delay).await {
+        Either::Left((output, _)) => Ok(output),
+        Either::Right(((), _)) => Err(Error::AuthError("Handshake timeout".into())),
+    }
+}
 
 /// Type alias for general message callbacks.
 pub type GeneralMessageCallback = Box<
@@ -678,9 +718,8 @@ impl<W: WalletInterface + 'static, T: Transport + 'static> Peer<W, T> {
 
         // Wait for response with timeout
         let timeout = max_wait_time.unwrap_or(30000);
-        let result = tokio::time::timeout(tokio::time::Duration::from_millis(timeout), rx)
-            .await
-            .map_err(|_| Error::AuthError("Handshake timeout".into()))?
+        let result = wait_with_timeout(rx, timeout)
+            .await?
             .map_err(|_| Error::AuthError("Handshake cancelled".into()))??;
 
         Ok(result)


### PR DESCRIPTION
## Summary
- Makes `Peer::initiate_handshake` wasm32-compatible by cfg-gating its `tokio::time::timeout` call to use `futures_timer::Delay` on wasm32 + the existing `tokio::time::timeout` on native.
- Adds optional `futures-timer = "3"` dep behind the existing `wasm` feature.
- Bumps version to 0.3.8.

## Motivation
The bsv-mpc Phase H Step 3 POC at `~/bsv/mpc/bsv-mpc/poc/poc17-cf-outbound-ws/` (Cloudflare Worker, wasm32-unknown-unknown) needs `Peer::initiate_handshake` to drive BRC-103 mutual auth from CF Worker scope. The current `tokio::time::timeout` at `src/auth/peer.rs:681` requires a tokio runtime time-driver, which CF Workers don't have — `initiate_handshake` panics at runtime in wasm32. The POC currently routes around this with a manual Path 2 InitialRequest construction; v0.3.8 makes the canonical `Peer` API wasm32-usable.

## Wire & API compatibility
- **Backward compatible.** Native callers see zero behavioral change (the cfg-gated body falls through to the original `tokio::time::timeout`).
- New `wasm` feature behavior: `features = ["auth", "wasm"]` now pulls `futures-timer` and the cfg-gated wasm32 body is available.

## Test plan
- [x] `cargo test --features auth` — 898 lib tests pass (worktree-local)
- [x] `cargo build --features auth,wasm --target wasm32-unknown-unknown` — clean
- [x] `cargo clippy --all-targets --features auth,wasm -- -D warnings` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo publish --dry-run --allow-dirty` — packaged + verified
- [ ] CI matrix (ubuntu/macos/windows × stable/beta) on this PR

## Downstream consumers
- `~/bsv/mpc/bsv-mpc/poc/poc17-cf-outbound-ws/` — currently uses Path 2 manual handshake (commit `358f121` H-3.3b in bsv-mpc); migrates to the canonical `Peer::initiate_handshake` in Phase H Step 4.
- No public consumers blocked on this; the bsv-mpc partnership POC is the first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)