### PR TITLE
v0.3.9: wasm32 SystemTime::now panic fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,10 @@ futures = "0.3"
 # Runtime-agnostic timer (wasm32 only — CF Workers have no tokio time-driver)
 futures-timer = { version = "3", optional = true }
 
+# JS host bindings (wasm32 only — std::time::SystemTime is unimplemented on
+# wasm32-unknown-unknown, so wall-clock helpers use `js_sys::Date::now()` there)
+js-sys = { version = "0.3", optional = true }
+
 # URL encoding (for storage module)
 urlencoding = "2.1"
 
@@ -98,7 +102,7 @@ storage = ["overlay"]
 registry = ["overlay"]
 kvstore = ["overlay"]
 identity = ["auth", "overlay"]
-wasm = ["getrandom/js", "dep:futures-timer"]
+wasm = ["getrandom/js", "dep:futures-timer", "dep:js-sys"]
 full = ["primitives", "script", "transaction", "wallet", "messages", "compat", "totp", "auth", "overlay", "storage", "registry", "kvstore", "identity"]
 http = ["dep:reqwest"]
 websocket = ["auth", "dep:tokio-tungstenite", "dep:futures-util"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bsv-rs"
-version = "0.3.8"
+version = "0.3.9"
 edition = "2021"
 description = "BSV blockchain SDK for Rust - primitives, script, transactions, and more"
 license = "MIT OR Apache-2.0"

--- a/src/auth/types.rs
+++ b/src/auth/types.rs
@@ -390,11 +390,13 @@ impl RequestedCertificateSet {
 }
 
 /// Returns current time in milliseconds since Unix epoch.
+///
+/// On `wasm32-unknown-unknown` (e.g. Cloudflare Workers) this uses
+/// `js_sys::Date::now()` because `std::time::SystemTime::now()` is
+/// unimplemented and panics there. On all other targets the behavior is
+/// unchanged. See `crate::util::time` for the cfg-gated implementation.
 pub fn current_time_ms() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_millis() as u64)
-        .unwrap_or(0)
+    crate::util::time::current_time_ms()
 }
 
 #[cfg(test)]

--- a/src/kvstore/types.rs
+++ b/src/kvstore/types.rs
@@ -478,11 +478,7 @@ struct TtlEnvelope {
 ///
 /// The value is wrapped in a JSON envelope: `{"v":"<value>","e":<unix_ts>}`
 pub(crate) fn encode_value_with_ttl(value: &str, ttl: std::time::Duration) -> String {
-    let expiration = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs()
-        + ttl.as_secs();
+    let expiration = crate::util::time::current_time_secs() + ttl.as_secs();
 
     let envelope = TtlEnvelope {
         v: value.to_string(),
@@ -500,10 +496,7 @@ pub(crate) fn encode_value_with_ttl(value: &str, ttl: std::time::Duration) -> St
 pub(crate) fn decode_value_with_ttl(stored: &str) -> (String, bool) {
     // Try to parse as TTL envelope
     if let Ok(envelope) = serde_json::from_str::<TtlEnvelope>(stored) {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
+        let now = crate::util::time::current_time_secs();
 
         let is_expired = now >= envelope.e;
         (envelope.v, is_expired)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,10 @@
 pub mod error;
 pub use error::{Error, Result};
 
+// Internal utilities (wasm32-safe time helpers, etc.). Not part of the
+// public API — see `src/util/mod.rs`.
+pub(crate) mod util;
+
 // Feature-gated modules
 #[cfg(feature = "primitives")]
 pub mod primitives;

--- a/src/overlay/host_reputation_tracker.rs
+++ b/src/overlay/host_reputation_tracker.rs
@@ -26,7 +26,6 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::RwLock;
-use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::broadcast;
 
 /// Default capacity for the rank change broadcast channel.
@@ -551,10 +550,7 @@ impl HostReputationTracker {
 
 /// Get current time in milliseconds since epoch.
 fn now_ms() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_millis() as u64
+    crate::util::time::current_time_ms()
 }
 
 // Global singleton

--- a/src/overlay/lookup_resolver.rs
+++ b/src/overlay/lookup_resolver.rs
@@ -636,10 +636,7 @@ impl Default for LookupResolver {
 
 /// Get current time in milliseconds since epoch.
 fn now_ms() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_millis() as u64
+    crate::util::time::current_time_ms()
 }
 
 #[cfg(test)]

--- a/src/storage/downloader.rs
+++ b/src/storage/downloader.rs
@@ -11,7 +11,6 @@ use crate::script::templates::PushDrop;
 use crate::transaction::Transaction;
 use crate::{Error, Result};
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::types::DownloadResult;
 use super::utils::is_valid_url;
@@ -101,10 +100,7 @@ impl StorageDownloader {
             _ => return Ok(Vec::new()),
         };
 
-        let current_time = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs() as i64;
+        let current_time = crate::util::time::current_time_secs() as i64;
 
         let mut hosts = Vec::new();
 

--- a/src/totp/core.rs
+++ b/src/totp/core.rs
@@ -3,7 +3,6 @@
 //! Implements RFC 6238 for generating time-based OTPs commonly used in 2FA.
 
 use crate::primitives::hash::{sha1_hmac, sha256_hmac, sha512_hmac};
-use std::time::{SystemTime, UNIX_EPOCH};
 use subtle::ConstantTimeEq;
 
 /// HMAC algorithm for TOTP generation.
@@ -279,10 +278,7 @@ fn generate_hotp(secret: &[u8], counter: u64, options: &TotpOptions) -> String {
 
 /// Get current Unix timestamp in seconds.
 fn current_unix_seconds() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("System time is before Unix epoch")
-        .as_secs()
+    crate::util::time::current_time_secs()
 }
 
 /// Constant-time string comparison to prevent timing attacks.

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,0 +1,7 @@
+//! Internal utilities shared across crate modules.
+//!
+//! Nothing in this module is part of the public API; it exists purely to
+//! provide cfg-gated helpers (e.g. wasm32-safe time) that several feature
+//! gates need without forcing them to depend on each other.
+
+pub(crate) mod time;

--- a/src/util/time.rs
+++ b/src/util/time.rs
@@ -1,0 +1,72 @@
+//! Wasm32-safe wall-clock helpers.
+//!
+//! `std::time::SystemTime::now()` is not implemented on
+//! `wasm32-unknown-unknown` — calling it panics at runtime (it traps with
+//! `unreachable!()` from libstd before returning a `Result`, so callers
+//! can't even `unwrap_or` their way out). That blocks any downstream that
+//! drives BSV protocol code from inside a Cloudflare Worker or similar
+//! `wasm32-unknown-unknown` host.
+//!
+//! These helpers cfg-gate the implementation:
+//!
+//! - Native (default): delegate to `std::time::SystemTime::now()` exactly
+//!   as before. Native callers see zero behavioral change.
+//! - `wasm32-unknown-unknown` with the `wasm` feature: use
+//!   `js_sys::Date::now()`, which returns milliseconds since the Unix
+//!   epoch as an `f64` and is available in every JS host (browsers,
+//!   Node.js, Cloudflare Workers, Deno). Sub-millisecond precision is
+//!   lost — `js_sys::Date::now()` is millisecond-quantized — but
+//!   `SystemTime` is unreachable on this target so there is no
+//!   higher-precision alternative without pulling in a JS-specific dep
+//!   like `web-sys`'s `Performance` API.
+//!
+//! All helpers return monotonically-non-decreasing values relative to
+//! the Unix epoch; callers that previously computed
+//! `SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default()`
+//! can be ported by calling [`duration_since_unix_epoch`] directly.
+
+use std::time::Duration;
+
+/// Returns the wall-clock duration since the Unix epoch (1970-01-01 UTC).
+///
+/// Returns `Duration::ZERO` if the system clock is set before the Unix
+/// epoch (a near-impossible edge case on real deployments, but preserved
+/// so call sites that previously used `unwrap_or_default()` keep the same
+/// behavior).
+#[allow(dead_code)] // Not used by every feature combination.
+#[cfg(all(target_arch = "wasm32", feature = "wasm"))]
+pub(crate) fn duration_since_unix_epoch() -> Duration {
+    let ms = js_sys::Date::now();
+    if !ms.is_finite() || ms < 0.0 {
+        return Duration::ZERO;
+    }
+    // `Date::now()` is millisecond-quantized, so casting to u64 loses no
+    // information for any plausible wall-clock value (u64 milliseconds
+    // covers ~584 million years).
+    Duration::from_millis(ms as u64)
+}
+
+/// Returns the wall-clock duration since the Unix epoch (1970-01-01 UTC).
+#[allow(dead_code)] // Not used by every feature combination.
+#[cfg(not(all(target_arch = "wasm32", feature = "wasm")))]
+pub(crate) fn duration_since_unix_epoch() -> Duration {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+}
+
+/// Returns current wall-clock time in milliseconds since the Unix epoch.
+///
+/// Equivalent to `duration_since_unix_epoch().as_millis() as u64`.
+#[allow(dead_code)] // Not used by every feature combination.
+pub(crate) fn current_time_ms() -> u64 {
+    duration_since_unix_epoch().as_millis() as u64
+}
+
+/// Returns current wall-clock time in seconds since the Unix epoch.
+///
+/// Equivalent to `duration_since_unix_epoch().as_secs()`.
+#[allow(dead_code)] // Not used by every feature combination.
+pub(crate) fn current_time_secs() -> u64 {
+    duration_since_unix_epoch().as_secs()
+}

--- a/src/wallet/proto_wallet.rs
+++ b/src/wallet/proto_wallet.rs
@@ -663,10 +663,7 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
 fn get_iso_timestamp() -> String {
     // Simple timestamp without chrono dependency
     // Format: "2024-01-01T00:00:00.000Z"
-    use std::time::{SystemTime, UNIX_EPOCH};
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default();
+    let now = crate::util::time::duration_since_unix_epoch();
     let secs = now.as_secs();
     let millis = now.subsec_millis();
 


### PR DESCRIPTION
## Summary

Companion to v0.3.8 (`feat/wasm32-runtime-agnostic-timeout`). Same root
cause shape, different std API: `std::time::SystemTime::now()` is
unimplemented on `wasm32-unknown-unknown` and panics with
`unreachable!()` before returning a `Result`, so even
`.unwrap_or(...)` / `.unwrap_or_default()` fall-throughs are unreachable.

That blocks the H-3.4 POC in the partner project
(`bsv-mpc/poc/poc17-cf-outbound-ws/`). On every inbound BRC-103 message
the canonical `Peer::start()` callback path eventually calls
`PeerSession::touch()`, which calls `auth::current_time_ms()`, which
called `SystemTime::now()` and unwound the Worker:

```
[ERROR] Uncaught RuntimeError: unreachable
  at std[...]::panicking::panic_with_hook ...
  at <std[...]::time::SystemTime>::now ...
  at bsv_rs::auth::peer::Peer<W,T>::start::{{closure}}::{{closure}} ...
  at poc17_cf_outbound_ws::transport_socketio::dispatch::run_dispatch::{{closure}} ...
```

Same hazard for every other production `SystemTime::now()` call in the
crate: `storage::downloader`, `kvstore::types` (TTL envelopes),
`wallet::proto_wallet::get_iso_timestamp`, `totp::core`,
`overlay::host_reputation_tracker::now_ms`,
`overlay::lookup_resolver::now_ms`. Any one of them is a latent panic
for a wasm32-unknown-unknown consumer.

## Fix

Add a small internal `crate::util::time` module with cfg-gated helpers
(`duration_since_unix_epoch`, `current_time_ms`, `current_time_secs`)
and route every production call site through it.

- **Native (default)**: delegates to `std::time::SystemTime::now()`
  exactly as before. Native callers see zero behavioral change.
- **`wasm32-unknown-unknown` + `wasm` feature**: uses
  `js_sys::Date::now()`, which is available in every JS host
  (browsers, Node.js, Cloudflare Workers, Deno) and returns
  millisecond-quantized wall-clock ms since the Unix epoch.

`js-sys` is added as an optional dep and pulled in only via the
existing `wasm` feature:
`wasm = ["getrandom/js", "dep:futures-timer", "dep:js-sys"]`.
Same shape as v0.3.8 added `futures-timer`. No other dependency churn.

One nominal behavior change: `totp::core::current_unix_seconds` used to
`.expect("System time is before Unix epoch")` and panic if the local
clock was set before 1970. The new helper returns `0` instead — which
is identical to the wasm32 fallback and only matters on a misconfigured
native host, where a panic in TOTP generation was already an awful UX.

The one production `SystemTime::now()` site that remains is inside a
`#[cfg(test)]` block in `src/kvstore/local.rs` and is therefore not in
the wasm32 build product. Left untouched — test-only code is out of
scope for this fix.

Public API surface is unchanged: `auth::current_time_ms` keeps its
signature and behavior on every target it was already callable on, and
now additionally works on `wasm32-unknown-unknown`.

## Commits

1. `auth: make SystemTime::now wasm32-compatible` — the helper + refactor
   of every production call site (8 files touched, 2 new helper files).
2. `v0.3.9: cut release for wasm32 SystemTime::now panic fix` — version
   bump in `Cargo.toml` only.

## Test plan

- [x] `cargo test --features auth` — 1564 passed, 0 failed (matches
      v0.3.8 baseline exactly)
- [x] `cargo build --features auth,wasm --target wasm32-unknown-unknown`
      — clean
- [x] `cargo clippy --all-targets --features auth,wasm -- -D warnings`
      (native) — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
      (native) — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --all-features` — clean
- [ ] Downstream H-3.4 POC re-run against v0.3.9 (consumer-side, after
      this merges and is published)

🤖 Generated with [Claude Code](https://claude.com/claude-code)