### PR TITLE
feat(auth): substrate-agnostic Socket.IO + BRC-103 transport

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,9 +103,14 @@ registry = ["overlay"]
 kvstore = ["overlay"]
 identity = ["auth", "overlay"]
 wasm = ["getrandom/js", "dep:futures-timer", "dep:js-sys"]
-full = ["primitives", "script", "transaction", "wallet", "messages", "compat", "totp", "auth", "overlay", "storage", "registry", "kvstore", "identity"]
+full = ["primitives", "script", "transaction", "wallet", "messages", "compat", "totp", "auth", "overlay", "storage", "registry", "kvstore", "identity", "socketio"]
 http = ["dep:reqwest"]
 websocket = ["auth", "dep:tokio-tungstenite", "dep:futures-util"]
+# Socket.IO 5 / Engine.IO 4 + BRC-103 transport. Substrate-agnostic:
+# pulls in no new dependency (uses serde_json + async-trait + futures,
+# all already required by `auth`), so enabling it cannot break a wasm32
+# `auth` build.
+socketio = ["auth"]
 dhat-profiling = ["dep:dhat"]
 
 [[bench]]

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -72,6 +72,11 @@ pub mod utils;
 pub use certificates::{Certificate, MasterCertificate, VerifiableCertificate};
 pub use peer::{Peer, PeerOptions};
 pub use session_manager::SessionManager;
+#[cfg(feature = "socketio")]
+pub use transports::{
+    install_app_event_listener, run_dispatch, AppEvent, SocketIoFrameSource, SocketIoSink,
+    SocketIoTransport,
+};
 pub use transports::{MockTransport, SimplifiedFetchTransport, Transport};
 #[cfg(feature = "websocket")]
 pub use transports::{WebSocketTransport, WebSocketTransportOptions};

--- a/src/auth/transports/mod.rs
+++ b/src/auth/transports/mod.rs
@@ -7,6 +7,8 @@
 //!
 //! - [`SimplifiedFetchTransport`] - HTTP-based transport (requires `http` feature)
 //! - `WebSocketTransport` - WebSocket-based transport (requires `websocket` feature)
+//! - `SocketIoTransport` - Socket.IO + BRC-103 transport, generic over a
+//!   WS substrate (requires `socketio` feature). See [`socketio`].
 //! - [`MockTransport`] - Mock transport for testing
 //!
 //! ## Custom Transports
@@ -40,6 +42,9 @@ pub mod http;
 #[cfg(feature = "websocket")]
 pub mod websocket_transport;
 
+#[cfg(feature = "socketio")]
+pub mod socketio;
+
 pub use http::{
     headers, HttpRequest, HttpResponse, MockTransport, SimplifiedFetchTransport, Transport,
     TransportCallback,
@@ -47,3 +52,9 @@ pub use http::{
 
 #[cfg(feature = "websocket")]
 pub use websocket_transport::{WebSocketTransport, WebSocketTransportOptions};
+
+#[cfg(feature = "socketio")]
+pub use socketio::{
+    install_app_event_listener, run_dispatch, AppEvent, SocketIoFrameSource, SocketIoSink,
+    SocketIoTransport,
+};

--- a/src/auth/transports/socketio/codec.rs
+++ b/src/auth/transports/socketio/codec.rs
@@ -49,9 +49,9 @@
 //!   - `0`              → CONNECT to default namespace (client → server)
 //!   - `0{"sid":"x"}`   → server CONNECT ack to default ns
 //!   - `0/admin,`       → CONNECT to /admin
-//!   - `2["foo","bar"]` → EVENT [foo, bar] on default ns
-//!   - `2/admin,["x"]`  → EVENT [x] on /admin
-//!   - `212["foo"]`     → EVENT [foo] on default ns with ack id 12
+//!   - `2["foo","bar"]` → EVENT `[foo, bar]` on default ns
+//!   - `2/admin,["x"]`  → EVENT `[x]` on /admin
+//!   - `212["foo"]`     → EVENT `[foo]` on default ns with ack id 12
 //!
 //! Only the no-namespace and default-`/` namespace cases are exercised
 //! by [`SocketIoTransport`](super::SocketIoTransport), but the parser

--- a/src/auth/transports/socketio/codec.rs
+++ b/src/auth/transports/socketio/codec.rs
@@ -1,0 +1,652 @@
+//! Engine.IO v4 + Socket.IO v5 packet codec.
+//!
+//! Target-agnostic (no WS substrate, no async) — encodes and decodes
+//! both server-bound and client-bound packets. It is the wire-format
+//! foundation under [`SocketIoTransport`](super::SocketIoTransport): the
+//! transport encodes a BRC-103 `AuthMessage` as a Socket.IO `EVENT`
+//! whose data array is `["authMessage", <json>]`, and the inbound
+//! dispatch loop decodes Engine.IO `Message(4)` frames back through this
+//! codec.
+//!
+//! # Attribution
+//!
+//! Vendored byte-identical from the Calhooon Socket.IO relay codec
+//! (`bsv-messagebox-cloudflare`, MIT licensed) so client and server
+//! agree on the wire byte-for-byte. Upstreamed here so any bsv-rs
+//! consumer can speak Engine.IO 4 / Socket.IO 5 without re-deriving it.
+//!
+//! # Engine.IO packets
+//!
+//! Each packet on the wire is `<type-digit>[<payload>]`:
+//!
+//! | Type    | Code | Direction       | Notes                                              |
+//! |---------|------|-----------------|----------------------------------------------------|
+//! | open    | `0`  | server → client | handshake JSON: `{sid,upgrades,pingInterval,...}`  |
+//! | close   | `1`  | bidirectional   | terminate transport                                |
+//! | ping    | `2`  | bidirectional   | heartbeat (or `2probe` during transport upgrade)   |
+//! | pong    | `3`  | bidirectional   | heartbeat reply (or `3probe` during upgrade)       |
+//! | message | `4`  | bidirectional   | carries a Socket.IO packet in the payload          |
+//! | upgrade | `5`  | client → server | client commits to the upgraded transport           |
+//! | noop    | `6`  | server → client | flushes a pending HTTP poll (used during upgrade)  |
+//!
+//! Polling format: when an HTTP body carries multiple Engine.IO packets,
+//! they are concatenated using the U+001E "record separator" (`\x1e`).
+//!
+//! # Socket.IO packets (carried in Engine.IO `4` payloads)
+//!
+//! Format: `<type-digit>[<nsp>,][<ack-id>][<json-payload>]`
+//!
+//! | Type           | Code |
+//! |----------------|------|
+//! | CONNECT        | `0`  |
+//! | DISCONNECT     | `1`  |
+//! | EVENT          | `2`  |
+//! | ACK            | `3`  |
+//! | CONNECT_ERROR  | `4`  |
+//!
+//! The namespace is OMITTED when it is the default `/`. When present it
+//! is followed by a single `,` separator. Examples:
+//!   - `0`              → CONNECT to default namespace (client → server)
+//!   - `0{"sid":"x"}`   → server CONNECT ack to default ns
+//!   - `0/admin,`       → CONNECT to /admin
+//!   - `2["foo","bar"]` → EVENT [foo, bar] on default ns
+//!   - `2/admin,["x"]`  → EVENT [x] on /admin
+//!   - `212["foo"]`     → EVENT [foo] on default ns with ack id 12
+//!
+//! Only the no-namespace and default-`/` namespace cases are exercised
+//! by [`SocketIoTransport`](super::SocketIoTransport), but the parser
+//! handles arbitrary namespaces correctly so non-standard clients still
+//! parse.
+
+use serde_json::Value;
+
+/// U+001E record separator used between concatenated Engine.IO
+/// packets in HTTP polling bodies.
+pub const RECORD_SEP: char = '\x1e';
+
+// ============================================================================
+// Engine.IO
+// ============================================================================
+
+/// One Engine.IO packet in decoded form. The payload (when present) is
+/// kept as `String` because the polling/WS transports always speak text
+/// for the AuthSocket use-case.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EngineIoPacket {
+    /// Server → client open packet. Payload is the handshake JSON.
+    Open(String),
+    /// Close (transport teardown).
+    Close,
+    /// Engine.IO ping. The probe variant carries `"probe"` as payload
+    /// during the WS upgrade dance; bare heartbeats have no payload.
+    Ping(String),
+    /// Engine.IO pong, mirror of [`EngineIoPacket::Ping`].
+    Pong(String),
+    /// Engine.IO message packet. Payload is the Socket.IO-encoded packet
+    /// as a string (encoded by [`SocketIoPacket::encode`]).
+    Message(String),
+    /// Client → server upgrade commit packet. No payload.
+    Upgrade,
+    /// Server → client noop, used to flush a pending HTTP poll mid-upgrade.
+    Noop,
+}
+
+impl EngineIoPacket {
+    /// Encode this packet to its on-the-wire string form.
+    pub fn encode(&self) -> String {
+        match self {
+            EngineIoPacket::Open(payload) => format!("0{payload}"),
+            EngineIoPacket::Close => "1".to_string(),
+            EngineIoPacket::Ping(payload) => format!("2{payload}"),
+            EngineIoPacket::Pong(payload) => format!("3{payload}"),
+            EngineIoPacket::Message(payload) => format!("4{payload}"),
+            EngineIoPacket::Upgrade => "5".to_string(),
+            EngineIoPacket::Noop => "6".to_string(),
+        }
+    }
+
+    /// Decode a single Engine.IO packet from a string. Returns an error
+    /// for empty input or unknown leading digit.
+    pub fn decode(raw: &str) -> Result<Self, CodecError> {
+        let mut chars = raw.chars();
+        let head = chars.next().ok_or(CodecError::EmptyPacket)?;
+        let rest: String = chars.collect();
+        Ok(match head {
+            '0' => EngineIoPacket::Open(rest),
+            '1' => EngineIoPacket::Close,
+            '2' => EngineIoPacket::Ping(rest),
+            '3' => EngineIoPacket::Pong(rest),
+            '4' => EngineIoPacket::Message(rest),
+            '5' => {
+                if !rest.is_empty() {
+                    return Err(CodecError::Malformed(format!(
+                        "upgrade packet must have no payload, got {rest:?}"
+                    )));
+                }
+                EngineIoPacket::Upgrade
+            }
+            '6' => {
+                if !rest.is_empty() {
+                    return Err(CodecError::Malformed(format!(
+                        "noop packet must have no payload, got {rest:?}"
+                    )));
+                }
+                EngineIoPacket::Noop
+            }
+            other => return Err(CodecError::UnknownType(other)),
+        })
+    }
+}
+
+/// Encode a batch of packets into a single HTTP polling body using
+/// the `\x1e` record separator.
+pub fn encode_polling_batch(packets: &[EngineIoPacket]) -> String {
+    let mut out = String::new();
+    for (i, p) in packets.iter().enumerate() {
+        if i > 0 {
+            out.push(RECORD_SEP);
+        }
+        out.push_str(&p.encode());
+    }
+    out
+}
+
+/// Decode an HTTP polling body that may contain one or more concatenated
+/// Engine.IO packets. Empty input yields an empty `Vec`, which represents
+/// an empty body (treated as "client poll with no inbound data" by
+/// callers).
+pub fn decode_polling_batch(raw: &str) -> Result<Vec<EngineIoPacket>, CodecError> {
+    if raw.is_empty() {
+        return Ok(Vec::new());
+    }
+    raw.split(RECORD_SEP).map(EngineIoPacket::decode).collect()
+}
+
+// ============================================================================
+// Socket.IO
+// ============================================================================
+
+/// Decoded Socket.IO packet. `BINARY_EVENT` / `BINARY_ACK` are
+/// intentionally omitted because the AuthSocket transport never sends
+/// binary attachments — the JSON payload carries everything.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SocketIoPacket {
+    /// CONNECT (type 0). Client → server: optional auth payload.
+    /// Server → client: `{ sid: <socket-sid> }`.
+    Connect {
+        /// Namespace this packet targets (`/` for default).
+        nsp: String,
+        /// Optional JSON payload (auth on client side, `{sid}` on server side).
+        data: Option<Value>,
+    },
+    /// DISCONNECT (type 1). No payload.
+    Disconnect {
+        /// Namespace being disconnected.
+        nsp: String,
+    },
+    /// EVENT (type 2). Payload is the JSON array `[event_name, ...args]`.
+    Event {
+        /// Namespace the event was emitted on.
+        nsp: String,
+        /// Optional ack correlation id.
+        ack_id: Option<u64>,
+        /// The event JSON array — `data[0]` is the event name.
+        data: Vec<Value>,
+    },
+    /// ACK (type 3). Same shape as EVENT but `ack_id` is mandatory.
+    Ack {
+        /// Namespace the ack was emitted on.
+        nsp: String,
+        /// Ack correlation id (mirrors the originating EVENT's ack id).
+        ack_id: u64,
+        /// The ack JSON array of return arguments.
+        data: Vec<Value>,
+    },
+    /// CONNECT_ERROR (type 4). Payload is the rejection reason object.
+    ConnectError {
+        /// Namespace the connection was rejected on.
+        nsp: String,
+        /// Optional rejection reason JSON.
+        data: Option<Value>,
+    },
+}
+
+const DEFAULT_NSP: &str = "/";
+
+impl SocketIoPacket {
+    /// Borrow the namespace string for this packet.
+    pub fn nsp(&self) -> &str {
+        match self {
+            SocketIoPacket::Connect { nsp, .. }
+            | SocketIoPacket::Disconnect { nsp }
+            | SocketIoPacket::Event { nsp, .. }
+            | SocketIoPacket::Ack { nsp, .. }
+            | SocketIoPacket::ConnectError { nsp, .. } => nsp,
+        }
+    }
+
+    /// Encode this packet to the on-the-wire string form (without the
+    /// surrounding Engine.IO `4` prefix — wrap with
+    /// `EngineIoPacket::Message(s.encode())` to send).
+    pub fn encode(&self) -> String {
+        let mut out = String::new();
+        let type_code = match self {
+            SocketIoPacket::Connect { .. } => '0',
+            SocketIoPacket::Disconnect { .. } => '1',
+            SocketIoPacket::Event { .. } => '2',
+            SocketIoPacket::Ack { .. } => '3',
+            SocketIoPacket::ConnectError { .. } => '4',
+        };
+        out.push(type_code);
+
+        // Namespace prefix: only present when non-default. Followed by `,`.
+        let nsp = self.nsp();
+        if nsp != DEFAULT_NSP {
+            out.push_str(nsp);
+            out.push(',');
+        }
+
+        // Ack id (decimal) — encoded between the namespace and the JSON
+        // payload, with no separator.
+        if let SocketIoPacket::Event {
+            ack_id: Some(id), ..
+        } = self
+        {
+            out.push_str(&id.to_string());
+        }
+        if let SocketIoPacket::Ack { ack_id, .. } = self {
+            out.push_str(&ack_id.to_string());
+        }
+
+        // JSON payload — only present for some packet types.
+        match self {
+            SocketIoPacket::Connect { data, .. } | SocketIoPacket::ConnectError { data, .. } => {
+                if let Some(v) = data {
+                    out.push_str(&serde_json::to_string(v).unwrap_or_default());
+                }
+            }
+            SocketIoPacket::Event { data, .. } | SocketIoPacket::Ack { data, .. } => {
+                // Always serialize as a JSON array (mandatory per spec).
+                let arr = Value::Array(data.clone());
+                out.push_str(&serde_json::to_string(&arr).unwrap_or_default());
+            }
+            SocketIoPacket::Disconnect { .. } => {}
+        }
+        out
+    }
+
+    /// Decode a Socket.IO packet from the payload of an Engine.IO message
+    /// packet (i.e. without the leading `4`).
+    pub fn decode(raw: &str) -> Result<Self, CodecError> {
+        let mut chars = raw.chars();
+        let type_ch = chars.next().ok_or(CodecError::EmptyPacket)?;
+
+        // Optional namespace: if next char is `/`, read up to the first
+        // `,` (or end of string for type-only packets like CONNECT to
+        // /custom with no payload, where the wire form is `0/custom,`).
+        let mut rest: String = chars.collect();
+        let nsp = if rest.starts_with('/') {
+            // Find the comma that ends the namespace; if there's no
+            // comma, the entire remainder is the namespace.
+            if let Some(comma_idx) = rest.find(',') {
+                let ns = rest[..comma_idx].to_string();
+                rest = rest[comma_idx + 1..].to_string();
+                ns
+            } else {
+                let ns = rest.clone();
+                rest.clear();
+                ns
+            }
+        } else {
+            DEFAULT_NSP.to_string()
+        };
+
+        // Optional ack id: leading run of decimal digits.
+        let ack_digit_count = rest.chars().take_while(|c| c.is_ascii_digit()).count();
+        let ack_id: Option<u64> = if ack_digit_count > 0 {
+            rest[..ack_digit_count].parse().ok()
+        } else {
+            None
+        };
+        let payload = &rest[ack_digit_count..];
+
+        // Parse JSON payload if present.
+        let data: Option<Value> = if payload.is_empty() {
+            None
+        } else {
+            Some(serde_json::from_str(payload).map_err(|e| {
+                CodecError::Malformed(format!("invalid JSON in socket.io payload: {e}"))
+            })?)
+        };
+
+        Ok(match type_ch {
+            '0' => SocketIoPacket::Connect { nsp, data },
+            '1' => SocketIoPacket::Disconnect { nsp },
+            '2' => {
+                let arr = match data {
+                    Some(Value::Array(a)) if !a.is_empty() => a,
+                    Some(_) => {
+                        return Err(CodecError::Malformed(
+                            "socket.io EVENT payload must be a non-empty array".into(),
+                        ))
+                    }
+                    None => {
+                        return Err(CodecError::Malformed(
+                            "socket.io EVENT requires a payload".into(),
+                        ))
+                    }
+                };
+                SocketIoPacket::Event {
+                    nsp,
+                    ack_id,
+                    data: arr,
+                }
+            }
+            '3' => {
+                let arr = match data {
+                    Some(Value::Array(a)) => a,
+                    Some(_) => {
+                        return Err(CodecError::Malformed(
+                            "socket.io ACK payload must be an array".into(),
+                        ))
+                    }
+                    None => Vec::new(),
+                };
+                let id = ack_id.ok_or_else(|| {
+                    CodecError::Malformed("socket.io ACK requires an ack id".into())
+                })?;
+                SocketIoPacket::Ack {
+                    nsp,
+                    ack_id: id,
+                    data: arr,
+                }
+            }
+            '4' => SocketIoPacket::ConnectError { nsp, data },
+            other => {
+                return Err(CodecError::UnknownType(other));
+            }
+        })
+    }
+}
+
+// ============================================================================
+// Errors
+// ============================================================================
+
+/// Error returned by the Engine.IO / Socket.IO codec on malformed input.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CodecError {
+    /// The packet string was empty (no leading type digit).
+    EmptyPacket,
+    /// The leading type digit did not match any known packet type.
+    UnknownType(char),
+    /// The packet was structurally invalid (bad JSON, missing ack id, ...).
+    Malformed(String),
+}
+
+impl std::fmt::Display for CodecError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CodecError::EmptyPacket => write!(f, "empty packet"),
+            CodecError::UnknownType(c) => write!(f, "unknown packet type: {c:?}"),
+            CodecError::Malformed(s) => write!(f, "malformed packet: {s}"),
+        }
+    }
+}
+
+impl std::error::Error for CodecError {}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // ---------- Engine.IO ----------
+
+    #[test]
+    fn engineio_open_round_trips() {
+        let payload =
+            r#"{"sid":"x","upgrades":["websocket"],"pingInterval":25000,"pingTimeout":20000}"#;
+        let p = EngineIoPacket::Open(payload.to_string());
+        let s = p.encode();
+        assert!(s.starts_with('0'));
+        assert_eq!(EngineIoPacket::decode(&s).unwrap(), p);
+    }
+
+    #[test]
+    fn engineio_close_round_trips() {
+        let p = EngineIoPacket::Close;
+        assert_eq!(p.encode(), "1");
+        assert_eq!(EngineIoPacket::decode("1").unwrap(), p);
+    }
+
+    #[test]
+    fn engineio_ping_pong_no_payload() {
+        assert_eq!(EngineIoPacket::Ping("".into()).encode(), "2");
+        assert_eq!(EngineIoPacket::Pong("".into()).encode(), "3");
+        assert_eq!(
+            EngineIoPacket::decode("2").unwrap(),
+            EngineIoPacket::Ping("".into())
+        );
+        assert_eq!(
+            EngineIoPacket::decode("3").unwrap(),
+            EngineIoPacket::Pong("".into())
+        );
+    }
+
+    #[test]
+    fn engineio_ping_pong_probe() {
+        // The transport-upgrade probe sequence sends `2probe` / `3probe`
+        // — these MUST round-trip through the codec or upgrade fails.
+        assert_eq!(EngineIoPacket::Ping("probe".into()).encode(), "2probe");
+        assert_eq!(EngineIoPacket::Pong("probe".into()).encode(), "3probe");
+        assert_eq!(
+            EngineIoPacket::decode("2probe").unwrap(),
+            EngineIoPacket::Ping("probe".into())
+        );
+        assert_eq!(
+            EngineIoPacket::decode("3probe").unwrap(),
+            EngineIoPacket::Pong("probe".into())
+        );
+    }
+
+    #[test]
+    fn engineio_message_round_trips() {
+        let p = EngineIoPacket::Message("2[\"hello\"]".into());
+        assert_eq!(p.encode(), "42[\"hello\"]");
+        assert_eq!(EngineIoPacket::decode("42[\"hello\"]").unwrap(), p);
+    }
+
+    #[test]
+    fn engineio_upgrade_and_noop() {
+        assert_eq!(EngineIoPacket::Upgrade.encode(), "5");
+        assert_eq!(EngineIoPacket::Noop.encode(), "6");
+        assert_eq!(
+            EngineIoPacket::decode("5").unwrap(),
+            EngineIoPacket::Upgrade
+        );
+        assert_eq!(EngineIoPacket::decode("6").unwrap(), EngineIoPacket::Noop);
+    }
+
+    #[test]
+    fn engineio_decode_rejects_empty() {
+        assert_eq!(EngineIoPacket::decode(""), Err(CodecError::EmptyPacket));
+    }
+
+    #[test]
+    fn engineio_decode_rejects_unknown() {
+        assert!(matches!(
+            EngineIoPacket::decode("9foo"),
+            Err(CodecError::UnknownType('9'))
+        ));
+    }
+
+    #[test]
+    fn polling_batch_single_packet() {
+        let pkts = vec![EngineIoPacket::Message("2[\"a\"]".into())];
+        let s = encode_polling_batch(&pkts);
+        assert_eq!(s, "42[\"a\"]");
+        assert_eq!(decode_polling_batch(&s).unwrap(), pkts);
+    }
+
+    #[test]
+    fn polling_batch_multi_packet_uses_record_separator() {
+        // Spec sample from the protocol README: `42["hello"]\x1e42["world"]`.
+        let pkts = vec![
+            EngineIoPacket::Message("2[\"hello\"]".into()),
+            EngineIoPacket::Message("2[\"world\"]".into()),
+        ];
+        let s = encode_polling_batch(&pkts);
+        assert_eq!(s, "42[\"hello\"]\u{1e}42[\"world\"]");
+        assert_eq!(decode_polling_batch(&s).unwrap(), pkts);
+    }
+
+    #[test]
+    fn polling_batch_empty_string_yields_empty_vec() {
+        assert!(decode_polling_batch("").unwrap().is_empty());
+    }
+
+    // ---------- Socket.IO ----------
+
+    #[test]
+    fn socketio_connect_default_namespace_no_payload() {
+        // Client→server CONNECT: bare `0` (default namespace, no auth).
+        let p = SocketIoPacket::Connect {
+            nsp: "/".into(),
+            data: None,
+        };
+        assert_eq!(p.encode(), "0");
+        assert_eq!(SocketIoPacket::decode("0").unwrap(), p);
+    }
+
+    #[test]
+    fn socketio_connect_default_namespace_with_sid() {
+        // Server→client CONNECT ack: `0{"sid":"..."}`.
+        let p = SocketIoPacket::Connect {
+            nsp: "/".into(),
+            data: Some(json!({"sid":"wZX3oN0bSVIhsaknAAAI"})),
+        };
+        let s = p.encode();
+        assert_eq!(s, r#"0{"sid":"wZX3oN0bSVIhsaknAAAI"}"#);
+        assert_eq!(SocketIoPacket::decode(&s).unwrap(), p);
+    }
+
+    #[test]
+    fn socketio_connect_custom_namespace_with_payload() {
+        let p = SocketIoPacket::Connect {
+            nsp: "/admin".into(),
+            data: Some(json!({"token":"123"})),
+        };
+        let s = p.encode();
+        assert_eq!(s, r#"0/admin,{"token":"123"}"#);
+        assert_eq!(SocketIoPacket::decode(&s).unwrap(), p);
+    }
+
+    #[test]
+    fn socketio_disconnect_default_namespace() {
+        let p = SocketIoPacket::Disconnect { nsp: "/".into() };
+        assert_eq!(p.encode(), "1");
+        assert_eq!(SocketIoPacket::decode("1").unwrap(), p);
+    }
+
+    #[test]
+    fn socketio_disconnect_custom_namespace_round_trips() {
+        let p = SocketIoPacket::Disconnect {
+            nsp: "/admin".into(),
+        };
+        // Wire form per spec sample: `1/admin,`
+        assert_eq!(p.encode(), "1/admin,");
+        assert_eq!(SocketIoPacket::decode("1/admin,").unwrap(), p);
+    }
+
+    #[test]
+    fn socketio_event_default_namespace_round_trips() {
+        let p = SocketIoPacket::Event {
+            nsp: "/".into(),
+            ack_id: None,
+            data: vec![json!("foo"), json!("bar")],
+        };
+        let s = p.encode();
+        assert_eq!(s, r#"2["foo","bar"]"#);
+        assert_eq!(SocketIoPacket::decode(&s).unwrap(), p);
+    }
+
+    #[test]
+    fn socketio_event_custom_namespace_with_ack() {
+        let p = SocketIoPacket::Event {
+            nsp: "/admin".into(),
+            ack_id: Some(13),
+            data: vec![json!("foo")],
+        };
+        let s = p.encode();
+        assert_eq!(s, r#"2/admin,13["foo"]"#);
+        assert_eq!(SocketIoPacket::decode(&s).unwrap(), p);
+    }
+
+    #[test]
+    fn socketio_event_with_ack_id_default_namespace() {
+        // Spec example: `212["foo"]` with ack id 12.
+        let p = SocketIoPacket::Event {
+            nsp: "/".into(),
+            ack_id: Some(12),
+            data: vec![json!("foo")],
+        };
+        let s = p.encode();
+        assert_eq!(s, r#"212["foo"]"#);
+        assert_eq!(SocketIoPacket::decode(&s).unwrap(), p);
+    }
+
+    #[test]
+    fn socketio_ack_round_trips() {
+        let p = SocketIoPacket::Ack {
+            nsp: "/".into(),
+            ack_id: 12,
+            data: vec![json!("ok")],
+        };
+        let s = p.encode();
+        assert_eq!(s, r#"312["ok"]"#);
+        assert_eq!(SocketIoPacket::decode(&s).unwrap(), p);
+    }
+
+    #[test]
+    fn socketio_connect_error_round_trips() {
+        let p = SocketIoPacket::ConnectError {
+            nsp: "/".into(),
+            data: Some(json!({"message":"Not authorized"})),
+        };
+        let s = p.encode();
+        assert_eq!(s, r#"4{"message":"Not authorized"}"#);
+        assert_eq!(SocketIoPacket::decode(&s).unwrap(), p);
+    }
+
+    #[test]
+    fn socketio_event_rejects_non_array_payload() {
+        // Per spec: EVENT payload MUST be a non-empty array.
+        assert!(SocketIoPacket::decode("2{\"foo\":1}").is_err());
+        assert!(SocketIoPacket::decode("2[]").is_err());
+    }
+
+    #[test]
+    fn socketio_full_engineio_wrapped_event_decodes() {
+        // The full wire form a client sends for `socket.emit("test","hi")`
+        // on the default namespace: `42["test","hi"]`.
+        let eio = EngineIoPacket::decode("42[\"test\",\"hi\"]").unwrap();
+        let payload = match eio {
+            EngineIoPacket::Message(p) => p,
+            _ => panic!("expected message"),
+        };
+        let sio = SocketIoPacket::decode(&payload).unwrap();
+        match sio {
+            SocketIoPacket::Event { nsp, ack_id, data } => {
+                assert_eq!(nsp, "/");
+                assert_eq!(ack_id, None);
+                assert_eq!(data, vec![json!("test"), json!("hi")]);
+            }
+            _ => panic!("expected event"),
+        }
+    }
+}

--- a/src/auth/transports/socketio/mod.rs
+++ b/src/auth/transports/socketio/mod.rs
@@ -36,12 +36,12 @@
 //!
 //! # Application-event envelope
 //!
-//! Post-handshake [`MessageType::General`] payloads use the canonical
-//! `{eventName, data}` JSON envelope. [`build_envelope_payload`] and
-//! [`parse_app_event_payload`] encode and decode it byte-exactly against
-//! the TS canonical (`encodeEventPayload`); [`AppEvent`] is the decoded
-//! form. See [`install_app_event_listener`] to subscribe a [`Peer`] to a
-//! stream of decoded events.
+//! Post-handshake [`MessageType::General`](crate::auth::MessageType::General)
+//! payloads use the canonical `{eventName, data}` JSON envelope.
+//! [`build_envelope_payload`] and [`parse_app_event_payload`] encode and
+//! decode it byte-exactly against the TS canonical (`encodeEventPayload`);
+//! [`AppEvent`] is the decoded form. See [`install_app_event_listener`] to
+//! subscribe a [`Peer`](crate::auth::Peer) to a stream of decoded events.
 //!
 //! # Example
 //!
@@ -104,8 +104,8 @@ use codec::{EngineIoPacket, SocketIoPacket};
 /// transport maps it into [`crate::Error::AuthError`] at the boundary.
 ///
 /// Implementors must be `Send + Sync` so [`SocketIoTransport`] satisfies
-/// the [`Transport`] bound and can be shared across the [`Peer`] and the
-/// dispatch task.
+/// the [`Transport`] bound and can be shared across the
+/// [`Peer`](crate::auth::Peer) and the dispatch task.
 pub trait SocketIoSink: Send + Sync {
     /// Encode `pkt` (wrapped in an Engine.IO `Message(4)`) and write it
     /// to the wire. Returns `Err` if the underlying transport is closed.
@@ -344,9 +344,9 @@ pub struct AppEvent {
 /// id (pass it to `Peer::stop_listening_for_general_messages` on teardown
 /// if needed).
 ///
-/// Requires `Peer::start()` to have been called on the same [`Peer`] so
-/// the start-callback routes inbound Generals to the
-/// `general_message_callbacks` map this helper subscribes to.
+/// Requires `Peer::start()` to have been called on the same
+/// [`Peer`](crate::auth::Peer) so the start-callback routes inbound
+/// Generals to the `general_message_callbacks` map this helper subscribes to.
 pub async fn install_app_event_listener<W, T>(
     peer: &crate::auth::Peer<W, T>,
 ) -> (futures::channel::mpsc::UnboundedReceiver<AppEvent>, u32)

--- a/src/auth/transports/socketio/mod.rs
+++ b/src/auth/transports/socketio/mod.rs
@@ -1,0 +1,745 @@
+//! Socket.IO + BRC-103 transport for [`Peer`](crate::auth::Peer).
+//!
+//! [`SocketIoTransport`] implements [`Transport`] by driving the
+//! BRC-103 `authMessage` event channel over a Socket.IO 5 / Engine.IO 4
+//! connection. It is **substrate-agnostic**: rather than hard-coding a
+//! particular WebSocket stack, it is generic over a minimal outbound
+//! [`SocketIoSink`] (one method, `send_socketio`). Consumers plug in
+//! whatever they like — `tokio-tungstenite` and `reqwest` on native,
+//! `web_sys::WebSocket` and `worker::Fetch` on `wasm32`, the bsv-rs
+//! [`WebSocketTransport`](crate::auth::WebSocketTransport) machinery, or
+//! a test double. bsv-rs itself pulls in **no** new dependency for this
+//! module, so enabling it can never break a `wasm32` build that uses
+//! `auth` without it.
+//!
+//! The inbound side is symmetrical: [`run_dispatch`] is generic over a
+//! [`SocketIoFrameSource`] (one async method, `recv_engineio`) so the
+//! decode loop is decoupled from any concrete read half.
+//!
+//! # Wire shape (matches canonical TS `@bsv/authsocket-client`)
+//!
+//! **Outbound** — each [`AuthMessage`] is JSON-serialized and emitted as
+//! a Socket.IO `EVENT` whose data array is `["authMessage", <json>]` on
+//! the default namespace `/`. The canonical TS does
+//! `socket.emit('authMessage', message)`; on the wire that is a single
+//! Engine.IO `Message(4)` framing `42["authMessage",{<json>}]`. The byte
+//! form is identical because `socket.io-client` serializes the JS object
+//! via `JSON.stringify` exactly as `serde_json` serializes the Rust
+//! [`AuthMessage`] (camelCase, per its `#[serde(rename_all = "camelCase")]`).
+//!
+//! **Inbound** — [`run_dispatch`] decodes Engine.IO `Message(4)` frames,
+//! extracts the Socket.IO `EVENT` payload, matches `data[0] == "authMessage"`,
+//! deserializes `data[1]` as an [`AuthMessage`], and invokes the
+//! registered [`TransportCallback`]. Engine.IO `Ping` frames are
+//! auto-replied with `Pong` through a caller-supplied [`SocketIoSink`]
+//! clone so the relay's `pingTimeout` never fires mid-dispatch.
+//!
+//! # Application-event envelope
+//!
+//! Post-handshake [`MessageType::General`] payloads use the canonical
+//! `{eventName, data}` JSON envelope. [`build_envelope_payload`] and
+//! [`parse_app_event_payload`] encode and decode it byte-exactly against
+//! the TS canonical (`encodeEventPayload`); [`AppEvent`] is the decoded
+//! form. See [`install_app_event_listener`] to subscribe a [`Peer`] to a
+//! stream of decoded events.
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use bsv_rs::auth::transports::socketio::{SocketIoTransport, SocketIoSink, run_dispatch};
+//! use bsv_rs::auth::transports::socketio::codec::SocketIoPacket;
+//!
+//! // 1. Implement the one-method sink over your WS substrate.
+//! #[derive(Clone)]
+//! struct MySink(/* your cloneable WS sender */);
+//! impl SocketIoSink for MySink {
+//!     fn send_socketio(&self, pkt: &SocketIoPacket) -> Result<(), String> {
+//!         // self.0.send_text(&EngineIoPacket::Message(pkt.encode()).encode())
+//!         Ok(())
+//!     }
+//! }
+//!
+//! // 2. Build the transport, hand it to a Peer.
+//! let transport = SocketIoTransport::new(MySink(/* ... */));
+//! let callback = transport.callback_handle();
+//! let sink = transport.sink();
+//! // peer = Peer::new(PeerOptions { transport: transport.clone(), .. });
+//!
+//! // 3. Spawn the inbound dispatch over your WS read half.
+//! // tokio::spawn(run_dispatch(my_frame_source, sink, callback));
+//! ```
+
+pub mod codec;
+
+use std::sync::{Arc, Mutex as StdMutex};
+
+use async_trait::async_trait;
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::auth::transports::{Transport, TransportCallback};
+use crate::auth::types::AuthMessage;
+use crate::primitives::PublicKey;
+use crate::Result;
+
+use codec::{EngineIoPacket, SocketIoPacket};
+
+/// Minimal outbound sink for the Socket.IO transport.
+///
+/// Implement this over whatever WebSocket substrate you use. The single
+/// method serializes a [`SocketIoPacket`], wraps it in an Engine.IO
+/// `Message(4)` frame, and writes it to the wire. A blanket helper is
+/// not provided so implementors retain full control over framing and
+/// back-pressure; most implementations are a one-liner:
+///
+/// ```rust,ignore
+/// use bsv_rs::auth::transports::socketio::codec::EngineIoPacket;
+/// fn send_socketio(&self, pkt: &SocketIoPacket) -> Result<(), String> {
+///     self.ws.send_text(&EngineIoPacket::Message(pkt.encode()).encode())
+/// }
+/// ```
+///
+/// The error type is `String` (rather than [`crate::Error`]) so trivial
+/// substrate adapters need no dependency on the SDK error enum; the
+/// transport maps it into [`crate::Error::AuthError`] at the boundary.
+///
+/// Implementors must be `Send + Sync` so [`SocketIoTransport`] satisfies
+/// the [`Transport`] bound and can be shared across the [`Peer`] and the
+/// dispatch task.
+pub trait SocketIoSink: Send + Sync {
+    /// Encode `pkt` (wrapped in an Engine.IO `Message(4)`) and write it
+    /// to the wire. Returns `Err` if the underlying transport is closed.
+    fn send_socketio(&self, pkt: &SocketIoPacket) -> std::result::Result<(), String>;
+
+    /// Encode and send a raw [`EngineIoPacket`]. Used by [`run_dispatch`]
+    /// to reply to inbound `Ping` frames with `Pong`. The default
+    /// implementation only supports wrapping Socket.IO packets via
+    /// [`SocketIoSink::send_socketio`]; override to support bare
+    /// Engine.IO control frames (most substrates expose a `send_text`).
+    fn send_engineio(&self, pkt: &EngineIoPacket) -> std::result::Result<(), String> {
+        // Conservative default: only Message frames can be expressed via
+        // `send_socketio`. Control frames (Ping/Pong) require an override.
+        match pkt {
+            EngineIoPacket::Message(payload) => {
+                // Re-decode the inner Socket.IO packet and forward it.
+                match SocketIoPacket::decode(payload) {
+                    Ok(sio) => self.send_socketio(&sio),
+                    Err(e) => Err(format!("send_engineio default: {e}")),
+                }
+            }
+            other => Err(format!(
+                "send_engineio default impl cannot send {other:?}; override SocketIoSink::send_engineio"
+            )),
+        }
+    }
+}
+
+/// An inbound frame source for [`run_dispatch`].
+///
+/// Implement this over the read half of your WebSocket substrate. The
+/// dispatch loop calls [`recv_engineio`](SocketIoFrameSource::recv_engineio)
+/// repeatedly until it returns `Err` (connection closed).
+#[async_trait]
+pub trait SocketIoFrameSource: Send {
+    /// Await and decode the next inbound Engine.IO frame. Returns `Err`
+    /// when the underlying transport has closed; [`run_dispatch`] treats
+    /// any `Err` as end-of-stream and exits cleanly.
+    async fn recv_engineio(&mut self) -> std::result::Result<EngineIoPacket, String>;
+}
+
+/// [`Transport`] implementation over a Socket.IO `authMessage` event
+/// channel, generic over an outbound [`SocketIoSink`].
+///
+/// Cheap to clone (a [`SocketIoSink`] handle plus an `Arc`); use one
+/// clone per consumer — [`Peer`](crate::auth::Peer) consumes one, the
+/// [`run_dispatch`] task another.
+///
+/// Construct via [`SocketIoTransport::new`]; register a callback via the
+/// [`Transport::set_callback`] trait method (or indirectly by passing
+/// this transport into [`Peer::new`](crate::auth::Peer::new) and calling
+/// `Peer::start`). Use [`SocketIoTransport::callback_handle`] to obtain a
+/// clone of the callback slot for the dispatch task.
+#[derive(Clone)]
+pub struct SocketIoTransport<S: SocketIoSink> {
+    sink: S,
+    callback: Arc<StdMutex<Option<Box<TransportCallback>>>>,
+}
+
+impl<S: SocketIoSink + std::fmt::Debug> std::fmt::Debug for SocketIoTransport<S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SocketIoTransport")
+            .field("sink", &self.sink)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<S: SocketIoSink + Clone> SocketIoTransport<S> {
+    /// Wrap a [`SocketIoSink`] as a BRC-103 `authMessage` transport. The
+    /// callback slot starts empty; either call [`Transport::set_callback`]
+    /// directly or call `Peer::start` after passing this into
+    /// `Peer::new` to populate it.
+    pub fn new(sink: S) -> Self {
+        Self {
+            sink,
+            callback: Arc::new(StdMutex::new(None)),
+        }
+    }
+
+    /// Return a clone of the callback slot. The [`run_dispatch`] task
+    /// holds one of these so it can find the registered callback for
+    /// each inbound [`AuthMessage`]. Cloning the `Arc` does NOT clone the
+    /// callback itself — the registered `Box<TransportCallback>` lives
+    /// behind the shared `Mutex`.
+    pub fn callback_handle(&self) -> Arc<StdMutex<Option<Box<TransportCallback>>>> {
+        self.callback.clone()
+    }
+
+    /// A clone of the outbound sink. Useful for the dispatch loop, which
+    /// needs to write `Pong` replies on inbound `Ping` frames.
+    pub fn sink(&self) -> S {
+        self.sink.clone()
+    }
+}
+
+#[async_trait]
+impl<S: SocketIoSink + Clone + 'static> Transport for SocketIoTransport<S> {
+    async fn send(&self, message: &AuthMessage) -> Result<()> {
+        // Serialize the AuthMessage as the second arg of an
+        // `["authMessage", <msg>]` Socket.IO EVENT on the default
+        // namespace. The byte form is identical to the canonical TS
+        // `socket.emit('authMessage', message)` because socket.io-client
+        // serializes via `JSON.stringify` exactly as `serde_json` does
+        // the camelCase `AuthMessage`.
+        let json = serde_json::to_value(message).map_err(|e| {
+            crate::Error::AuthError(format!("SocketIoTransport::send: serialize: {e}"))
+        })?;
+        let pkt = SocketIoPacket::Event {
+            nsp: "/".to_string(),
+            ack_id: None,
+            data: vec![Value::String("authMessage".to_string()), json],
+        };
+        self.sink
+            .send_socketio(&pkt)
+            .map_err(|e| crate::Error::AuthError(format!("SocketIoTransport::send: ws: {e}")))
+    }
+
+    fn set_callback(&self, callback: Box<TransportCallback>) {
+        // `StdMutex` is safe here — it serializes the dispatch task vs.
+        // `Peer::start`. Poisoning is theoretical; if it happens we
+        // silently drop the registration, matching
+        // `SimplifiedFetchTransport`.
+        if let Ok(mut cb) = self.callback.lock() {
+            *cb = Some(callback);
+        }
+    }
+
+    fn clear_callback(&self) {
+        if let Ok(mut cb) = self.callback.lock() {
+            *cb = None;
+        }
+    }
+}
+
+// ============================================================================
+// Inbound dispatch loop
+// ============================================================================
+
+/// Background dispatch task body. Reads Engine.IO frames from a
+/// [`SocketIoFrameSource`] in a loop and:
+///
+/// - Replies to inbound Engine.IO `Ping` with `Pong` via the provided
+///   [`SocketIoSink`] so the relay heartbeat never fires.
+/// - On Engine.IO `Message(4)` carrying a Socket.IO `EVENT` whose
+///   `data[0]` is `"authMessage"`, deserializes `data[1]` as an
+///   [`AuthMessage`] and invokes the registered [`TransportCallback`]
+///   (typically the one `Peer::start` installs) so `Peer`'s session
+///   manager stays consistent.
+/// - Exits the loop on `recv_engineio` error (WS closed).
+///
+/// Drives one BRC-103 channel; spawn one of these per WebSocket. On
+/// native this future is `Send` when the `frames`/`sink`/callback `Arc`
+/// are `Send`, so it can run under `tokio::spawn`; on `wasm32` spawn it
+/// with `wasm_bindgen_futures::spawn_local`.
+pub async fn run_dispatch<F, S>(
+    mut frames: F,
+    sink: S,
+    callback: Arc<StdMutex<Option<Box<TransportCallback>>>>,
+) where
+    F: SocketIoFrameSource,
+    S: SocketIoSink,
+{
+    loop {
+        let frame = match frames.recv_engineio().await {
+            Ok(f) => f,
+            Err(_) => break, // WS closed — exit dispatch.
+        };
+        match frame {
+            EngineIoPacket::Ping(payload) => {
+                let _ = sink.send_engineio(&EngineIoPacket::Pong(payload));
+            }
+            EngineIoPacket::Message(payload) => {
+                let sio = match SocketIoPacket::decode(&payload) {
+                    Ok(p) => p,
+                    Err(_) => continue, // ignore malformed Socket.IO frames
+                };
+                if let SocketIoPacket::Event { data, .. } = sio {
+                    if data.len() >= 2 && data[0].as_str() == Some("authMessage") {
+                        let auth_msg: AuthMessage = match serde_json::from_value(data[1].clone()) {
+                            Ok(m) => m,
+                            Err(_) => continue,
+                        };
+
+                        // Synchronously invoke the callback under the lock
+                        // to produce the future; drop the lock before
+                        // awaiting. Same pattern as
+                        // `SimplifiedFetchTransport::invoke_callback`.
+                        let fut_opt = {
+                            match callback.lock() {
+                                Ok(guard) => guard.as_ref().map(|cb| cb(auth_msg)),
+                                Err(_) => None, // poisoned — drop the message
+                            }
+                        };
+                        if let Some(fut) = fut_opt {
+                            let _ = fut.await;
+                        }
+                    }
+                }
+            }
+            _ => { /* Open/Close/Pong/Upgrade/Noop — ignore */ }
+        }
+    }
+}
+
+// ============================================================================
+// Application-event envelope layer
+// ============================================================================
+
+/// One application-level event decoded from a post-BRC-103-handshake
+/// [`MessageType::General`](crate::auth::MessageType::General) payload.
+///
+/// The payload shape is the canonical `{eventName, data}` JSON envelope
+/// used by `@bsv/authsocket-client`'s `encodeEventPayload` — byte-identical
+/// between the TS canonical and this Rust client.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AppEvent {
+    /// The signing identity from the inbound General's `identity_key`
+    /// field — typically the server's identity key, but typed as
+    /// [`PublicKey`] so the same shape generalizes to peer-to-peer events.
+    pub sender: PublicKey,
+    /// The `eventName` field from the payload JSON. Empty string when the
+    /// payload was missing the field (still surfaced so callers can
+    /// observe malformed traffic instead of silently dropping it).
+    pub event_name: String,
+    /// The `data` field from the payload JSON. Type varies by event;
+    /// left as [`Value`] so callers parse the per-event shape themselves.
+    pub data: Value,
+}
+
+/// Install an inbound listener that decodes every post-BRC-103 General
+/// message payload as the canonical `{eventName, data}` envelope and
+/// forwards it on an unbounded `mpsc` channel.
+///
+/// The returned `Receiver` is the caller's queue of inbound application
+/// events; the `u32` is the `Peer::listen_for_general_messages` callback
+/// id (pass it to `Peer::stop_listening_for_general_messages` on teardown
+/// if needed).
+///
+/// Requires `Peer::start()` to have been called on the same [`Peer`] so
+/// the start-callback routes inbound Generals to the
+/// `general_message_callbacks` map this helper subscribes to.
+pub async fn install_app_event_listener<W, T>(
+    peer: &crate::auth::Peer<W, T>,
+) -> (futures::channel::mpsc::UnboundedReceiver<AppEvent>, u32)
+where
+    W: crate::wallet::WalletInterface + 'static,
+    T: Transport + 'static,
+{
+    let (tx, rx) = futures::channel::mpsc::unbounded::<AppEvent>();
+    let id = peer
+        .listen_for_general_messages(move |sender, payload| {
+            let tx = tx.clone();
+            Box::pin(async move {
+                let (event_name, data) = parse_app_event_payload(&payload);
+                let _ = tx.unbounded_send(AppEvent {
+                    sender,
+                    event_name,
+                    data,
+                });
+                Ok(())
+            })
+        })
+        .await;
+    (rx, id)
+}
+
+/// Parse a `{eventName, data}` JSON envelope from a General message's
+/// `payload` bytes. Returns `("", Value::Null)` on parse failure so
+/// callers can observe malformed traffic without panicking.
+pub fn parse_app_event_payload(payload: &[u8]) -> (String, Value) {
+    match serde_json::from_slice::<Value>(payload) {
+        Ok(json) => {
+            let event_name = json
+                .get("eventName")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let data = json.get("data").cloned().unwrap_or(Value::Null);
+            (event_name, data)
+        }
+        Err(_) => (String::new(), Value::Null),
+    }
+}
+
+/// Build the canonical `{eventName, data}` envelope as UTF-8 JSON bytes.
+///
+/// Byte-identical to the TS canonical `encodeEventPayload`:
+///
+/// ```ts
+/// private encodeEventPayload(eventName: string, data: any): number[] {
+///     const obj = { eventName, data }
+///     return Utils.toArray(JSON.stringify(obj), 'utf8')
+/// }
+/// ```
+///
+/// **Critical wire-compat detail**: JS `JSON.stringify` emits keys in
+/// object-literal **insertion order** (`{"eventName":...,"data":...}`).
+/// `serde_json::json!({...})` is `BTreeMap`-backed and would serialize
+/// **alphabetically** (`{"data":...,"eventName":...}`) unless the
+/// `preserve_order` feature is enabled. To match canonical TS without a
+/// crate-wide feature flip, this uses a typed `Envelope` struct, which
+/// serializes fields in **declaration order** (`eventName` first, `data`
+/// second). Verified by the byte-exact vector tests in this module.
+pub fn build_envelope_payload(event_name: &str, data: &Value) -> Vec<u8> {
+    #[derive(Serialize)]
+    struct Envelope<'a> {
+        #[serde(rename = "eventName")]
+        event_name: &'a str,
+        data: &'a Value,
+    }
+    let envelope = Envelope { event_name, data };
+    serde_json::to_vec(&envelope).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::types::MessageType;
+    use crate::primitives::PrivateKey;
+    use serde_json::json;
+
+    // ---------- authMessage EVENT framing (byte-exact) ----------
+
+    /// A trivial sink that records the last encoded Engine.IO frame so a
+    /// test can assert the exact wire bytes produced by `Transport::send`.
+    #[derive(Clone, Default)]
+    struct CapturingSink {
+        last: Arc<StdMutex<Option<String>>>,
+    }
+
+    impl SocketIoSink for CapturingSink {
+        fn send_socketio(&self, pkt: &SocketIoPacket) -> std::result::Result<(), String> {
+            let frame = EngineIoPacket::Message(pkt.encode()).encode();
+            *self.last.lock().unwrap() = Some(frame);
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn send_emits_authmessage_event_on_default_namespace() {
+        let sink = CapturingSink::default();
+        let transport = SocketIoTransport::new(sink.clone());
+
+        // A deterministic identity key so we can pin the wire bytes.
+        let key = PrivateKey::from_hex(
+            "0000000000000000000000000000000000000000000000000000000000000001",
+        )
+        .unwrap()
+        .public_key();
+        let msg = AuthMessage::new(MessageType::InitialRequest, key.clone());
+
+        transport.send(&msg).await.unwrap();
+
+        let frame = sink.last.lock().unwrap().clone().unwrap();
+        // Engine.IO Message(4) + Socket.IO EVENT(2) on default ns.
+        assert!(
+            frame.starts_with("42[\"authMessage\","),
+            "unexpected frame prefix: {frame}"
+        );
+
+        // Decode back through both layers and confirm the round-trip.
+        let eio = EngineIoPacket::decode(&frame).unwrap();
+        let payload = match eio {
+            EngineIoPacket::Message(p) => p,
+            other => panic!("expected Message, got {other:?}"),
+        };
+        let sio = SocketIoPacket::decode(&payload).unwrap();
+        match sio {
+            SocketIoPacket::Event { nsp, ack_id, data } => {
+                assert_eq!(nsp, "/");
+                assert_eq!(ack_id, None);
+                assert_eq!(data[0], json!("authMessage"));
+                let decoded: AuthMessage = serde_json::from_value(data[1].clone()).unwrap();
+                assert_eq!(decoded.message_type, MessageType::InitialRequest);
+                assert_eq!(decoded.identity_key.to_hex(), key.to_hex());
+            }
+            other => panic!("expected Event, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn send_authmessage_event_array_head_is_authmessage_literal() {
+        // Pin the exact event-name literal the canonical TS emits:
+        // `socket.emit('authMessage', message)` → data[0] == "authMessage".
+        let sink = CapturingSink::default();
+        let transport = SocketIoTransport::new(sink.clone());
+        let key = PrivateKey::random().public_key();
+        let msg = AuthMessage::new(MessageType::General, key);
+        transport.send(&msg).await.unwrap();
+
+        let frame = sink.last.lock().unwrap().clone().unwrap();
+        let payload = match EngineIoPacket::decode(&frame).unwrap() {
+            EngineIoPacket::Message(p) => p,
+            other => panic!("expected Message, got {other:?}"),
+        };
+        match SocketIoPacket::decode(&payload).unwrap() {
+            SocketIoPacket::Event { data, .. } => {
+                assert_eq!(data[0].as_str(), Some("authMessage"));
+            }
+            other => panic!("expected Event, got {other:?}"),
+        }
+    }
+
+    // ---------- {eventName, data} envelope (byte-exact vectors) ----------
+
+    #[test]
+    fn parse_app_event_decodes_joinroom_envelope() {
+        let payload = br#"{"eventName":"joinRoom","data":"02abc...xyz-payment_inbox"}"#;
+        let (event_name, data) = parse_app_event_payload(payload);
+        assert_eq!(event_name, "joinRoom");
+        assert_eq!(data, json!("02abc...xyz-payment_inbox"));
+    }
+
+    #[test]
+    fn parse_app_event_decodes_sendmessage_envelope() {
+        let payload = br#"{"eventName":"sendMessage","data":{"roomId":"02abc-test","message":{"messageId":"h34","body":"hello"}}}"#;
+        let (event_name, data) = parse_app_event_payload(payload);
+        assert_eq!(event_name, "sendMessage");
+        assert_eq!(
+            data,
+            json!({"roomId":"02abc-test","message":{"messageId":"h34","body":"hello"}})
+        );
+    }
+
+    #[test]
+    fn parse_app_event_decodes_sendmessageack_with_room_suffix() {
+        let payload = br#"{"eventName":"sendMessageAck-02abc-h34-test","data":{"status":"success","messageId":"h34"}}"#;
+        let (event_name, data) = parse_app_event_payload(payload);
+        assert_eq!(event_name, "sendMessageAck-02abc-h34-test");
+        assert_eq!(data["status"], json!("success"));
+        assert_eq!(data["messageId"], json!("h34"));
+    }
+
+    #[test]
+    fn parse_app_event_handles_empty_data() {
+        let payload = br#"{"eventName":"authenticated","data":{}}"#;
+        let (event_name, data) = parse_app_event_payload(payload);
+        assert_eq!(event_name, "authenticated");
+        assert_eq!(data, json!({}));
+    }
+
+    #[test]
+    fn parse_app_event_returns_empty_on_malformed_json() {
+        let payload = b"this is not json";
+        let (event_name, data) = parse_app_event_payload(payload);
+        assert_eq!(event_name, "");
+        assert_eq!(data, Value::Null);
+    }
+
+    #[test]
+    fn parse_app_event_returns_empty_on_missing_fields() {
+        let payload = br#"{"foo":"bar"}"#;
+        let (event_name, data) = parse_app_event_payload(payload);
+        assert_eq!(event_name, "");
+        assert_eq!(data, Value::Null);
+    }
+
+    #[test]
+    fn parse_app_event_handles_event_name_only() {
+        let payload = br#"{"eventName":"someEvent"}"#;
+        let (event_name, data) = parse_app_event_payload(payload);
+        assert_eq!(event_name, "someEvent");
+        assert_eq!(data, Value::Null);
+    }
+
+    #[test]
+    fn parse_app_event_byte_exact_against_ts_emit_vector() {
+        let canonical_ts_bytes: &[u8] = b"{\"eventName\":\"sendMessage\",\"data\":{\"roomId\":\"abc-test\",\"message\":{\"messageId\":\"v1\",\"body\":\"hi\"}}}";
+        let (event_name, data) = parse_app_event_payload(canonical_ts_bytes);
+        assert_eq!(event_name, "sendMessage");
+        assert_eq!(data["roomId"], json!("abc-test"));
+        assert_eq!(data["message"]["messageId"], json!("v1"));
+        assert_eq!(data["message"]["body"], json!("hi"));
+    }
+
+    #[test]
+    fn build_envelope_payload_joinroom_byte_exact() {
+        let bytes = build_envelope_payload("joinRoom", &json!("02abc-test_inbox"));
+        assert_eq!(
+            bytes.as_slice(),
+            b"{\"eventName\":\"joinRoom\",\"data\":\"02abc-test_inbox\"}".as_slice(),
+        );
+    }
+
+    #[test]
+    fn build_envelope_payload_sendmessage_byte_exact() {
+        // The wrapper's contract: `{"eventName":"<name>","data":<data verbatim>}`
+        // with the OUTER keys in `eventName`-then-`data` declaration order
+        // (the canonical JS `JSON.stringify({ eventName, data })` order).
+        // The nested `data` object is serialized by `serde_json` verbatim;
+        // we compose the expected vector from that serialization so the
+        // assertion is independent of whether `serde_json`'s
+        // `preserve_order` feature is active in the dependency graph.
+        let data = json!({"roomId": "abc-test", "message": {"messageId": "v1", "body": "hi"}});
+        let bytes = build_envelope_payload("sendMessage", &data);
+
+        let mut expected = b"{\"eventName\":\"sendMessage\",\"data\":".to_vec();
+        expected.extend_from_slice(&serde_json::to_vec(&data).unwrap());
+        expected.push(b'}');
+
+        assert_eq!(bytes, expected);
+        // And the outer `eventName` key MUST come first (declaration order).
+        assert!(bytes.starts_with(b"{\"eventName\":\"sendMessage\",\"data\":"));
+    }
+
+    #[test]
+    fn build_envelope_payload_leaveroom_byte_exact() {
+        let bytes = build_envelope_payload("leaveRoom", &json!("02abc-test_inbox"));
+        assert_eq!(
+            bytes.as_slice(),
+            b"{\"eventName\":\"leaveRoom\",\"data\":\"02abc-test_inbox\"}".as_slice(),
+        );
+    }
+
+    #[test]
+    fn build_envelope_payload_empty_data_object() {
+        let bytes = build_envelope_payload("authenticated", &json!({}));
+        assert_eq!(
+            bytes.as_slice(),
+            b"{\"eventName\":\"authenticated\",\"data\":{}}".as_slice(),
+        );
+    }
+
+    #[test]
+    fn build_envelope_payload_round_trips_through_parser() {
+        let cases: Vec<(&str, Value)> = vec![
+            ("joinRoom", json!("02abc-room")),
+            (
+                "sendMessage",
+                json!({"roomId": "02abc-room", "message": {"messageId": "m1", "body": "hi"}}),
+            ),
+            ("leaveRoom", json!("02abc-room")),
+            ("authenticated", json!({})),
+            ("sendMessageAck-02abc-room", json!({"status": "success"})),
+        ];
+        for (name, data) in cases {
+            let bytes = build_envelope_payload(name, &data);
+            let (decoded_name, decoded_data) = parse_app_event_payload(&bytes);
+            assert_eq!(decoded_name, name, "event_name round-trip for {name}");
+            assert_eq!(decoded_data, data, "data round-trip for {name}");
+        }
+    }
+
+    // ---------- inbound dispatch ----------
+
+    #[tokio::test]
+    async fn dispatch_routes_authmessage_event_to_callback() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        // A frame source that yields one authMessage EVENT then closes.
+        struct OneShotFrames {
+            frame: Option<EngineIoPacket>,
+        }
+        #[async_trait]
+        impl SocketIoFrameSource for OneShotFrames {
+            async fn recv_engineio(&mut self) -> std::result::Result<EngineIoPacket, String> {
+                self.frame.take().ok_or_else(|| "closed".to_string())
+            }
+        }
+
+        // Build the inbound frame: an authMessage EVENT carrying a General.
+        let key = PrivateKey::random().public_key();
+        let msg = AuthMessage::new(MessageType::General, key);
+        let json = serde_json::to_value(&msg).unwrap();
+        let sio = SocketIoPacket::Event {
+            nsp: "/".into(),
+            ack_id: None,
+            data: vec![json!("authMessage"), json],
+        };
+        let frame = EngineIoPacket::Message(sio.encode());
+
+        let count = Arc::new(AtomicUsize::new(0));
+        let count_cb = count.clone();
+        let callback: Arc<StdMutex<Option<Box<TransportCallback>>>> =
+            Arc::new(StdMutex::new(Some(Box::new(move |_m: AuthMessage| {
+                let count_cb = count_cb.clone();
+                Box::pin(async move {
+                    count_cb.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                })
+                    as std::pin::Pin<Box<dyn std::future::Future<Output = Result<()>> + Send>>
+            }))));
+
+        let sink = CapturingSink::default();
+        run_dispatch(OneShotFrames { frame: Some(frame) }, sink, callback).await;
+
+        assert_eq!(count.load(Ordering::SeqCst), 1, "callback should fire once");
+    }
+
+    #[tokio::test]
+    async fn dispatch_replies_pong_to_ping() {
+        // A frame source that yields one Ping then closes.
+        struct PingThenClose {
+            frame: Option<EngineIoPacket>,
+        }
+        #[async_trait]
+        impl SocketIoFrameSource for PingThenClose {
+            async fn recv_engineio(&mut self) -> std::result::Result<EngineIoPacket, String> {
+                self.frame.take().ok_or_else(|| "closed".to_string())
+            }
+        }
+
+        // A sink that records every engineio frame it is asked to send.
+        #[derive(Clone, Default)]
+        struct PongSink {
+            sent: Arc<StdMutex<Vec<String>>>,
+        }
+        impl SocketIoSink for PongSink {
+            fn send_socketio(&self, pkt: &SocketIoPacket) -> std::result::Result<(), String> {
+                self.sent
+                    .lock()
+                    .unwrap()
+                    .push(EngineIoPacket::Message(pkt.encode()).encode());
+                Ok(())
+            }
+            fn send_engineio(&self, pkt: &EngineIoPacket) -> std::result::Result<(), String> {
+                self.sent.lock().unwrap().push(pkt.encode());
+                Ok(())
+            }
+        }
+
+        let sink = PongSink::default();
+        let callback: Arc<StdMutex<Option<Box<TransportCallback>>>> = Arc::new(StdMutex::new(None));
+        run_dispatch(
+            PingThenClose {
+                frame: Some(EngineIoPacket::Ping(String::new())),
+            },
+            sink.clone(),
+            callback,
+        )
+        .await;
+
+        let sent = sink.sent.lock().unwrap();
+        assert_eq!(sent.len(), 1, "exactly one pong should be sent");
+        assert_eq!(sent[0], "3", "pong frame for a bare ping is `3`");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,11 @@ pub use compat::{Language, Mnemonic, WordCount};
 pub use totp::{Algorithm as TotpAlgorithm, Totp, TotpOptions, TotpValidateOptions};
 
 // Convenience re-exports from auth
+#[cfg(feature = "socketio")]
+pub use auth::{
+    install_app_event_listener, run_dispatch, AppEvent, SocketIoFrameSource, SocketIoSink,
+    SocketIoTransport,
+};
 #[cfg(feature = "auth")]
 pub use auth::{
     AuthMessage, Certificate, MasterCertificate, MessageType, Peer, PeerOptions, PeerSession,


### PR DESCRIPTION
## Summary

Adds **`SocketIoTransport`**, a `bsv::auth::Transport` implementation that drives the BRC-103 `authMessage` event channel over Socket.IO 5 / Engine.IO 4. Gated behind a new `socketio` feature (`= ["auth"]`). Also lands the target-agnostic Engine.IO/Socket.IO **codec** and the canonical `{eventName, data}` **application-event envelope** helpers.

Wire shape conforms byte-for-byte to canonical TS `@bsv/authsocket-client` — `socket.emit('authMessage', message)` → `42["authMessage",{<json>}]` (Path A: we conform to the wire, never the reverse).

## Design choice — and why

The source transport (in a sibling project) was hard-coupled to a specific `WsSender` (web_sys on wasm32, tokio mpsc on native). Two candidate upstream designs:

- **(A) Generic over a minimal sink + generic inbound dispatch** — `SocketIoTransport<S: SocketIoSink>` where `SocketIoSink` is one method (`send_socketio`), and `run_dispatch<F: SocketIoFrameSource>` is one async method (`recv_engineio`). bsv-rs stays 100% substrate-agnostic; consumers plug in tokio-tungstenite/reqwest, web_sys/worker, the existing `WebSocketTransport` machinery, or a test double.
- **(B) Batteries-included native client** atop the existing `websocket` transport (would force `tokio-tungstenite` into the feature).

**Chose (A).** It is the more reusable contribution and — critically — pulls in **no new dependency** (only `serde_json` + `async-trait` + `futures`, all already required by `auth`). That means enabling `socketio` **cannot break a wasm32 `auth` build**, which I verified (see gates). (B) would have coupled the feature to a native-only WS stack and a heavier dep surface. The codec and envelope helpers are target-agnostic and belong in the SDK regardless of substrate.

Scoping note: I deliberately did **not** port the sibling crate's `emit_signed_general` helper — it depends on `rand::thread_rng` and a concrete `ProtoWallet`, and encodes application policy (nonce generation, BRC-31 `key_id` format) rather than transport mechanism. It stays in the consumer. The reusable wire/transport core is what landed here.

## Files added/changed

| File | LOC | What |
|------|-----|------|
| `src/auth/transports/socketio/codec.rs` | +652 (new) | Engine.IO 4 + Socket.IO 5 packet codec (vendored byte-identical from the Calhooon relay codec), 21 round-trip/vector tests |
| `src/auth/transports/socketio/mod.rs` | +764 (new) | `SocketIoTransport<S>`, `SocketIoSink`, `SocketIoFrameSource`, `run_dispatch`, `AppEvent` + envelope helpers, 19 tests |
| `src/auth/transports/mod.rs` | +~13 | module + re-exports under `#[cfg(feature = "socketio")]` |
| `src/auth/mod.rs` | +~5 | re-exports |
| `src/lib.rs` | +~5 | convenience re-exports |
| `Cargo.toml` | +~6 | `socketio = ["auth"]` feature; added to `full` |

Includes byte-exact vector tests for the `authMessage` EVENT framing and the `{eventName,data}` envelope (ported from the source `mod tests`). One envelope vector was adjusted to compose its expected bytes from `serde_json::to_vec(&data)` so the assertion is robust whether or not `serde_json`'s `preserve_order` is active in the dependency graph — bsv-rs does not enable it, so a nested-object literal sorts keys alphabetically. The function itself preserves the outer `eventName`-then-`data` order via a typed struct (declaration order), matching JS `JSON.stringify`.

## Gate evidence (all green, 110%)

```
cargo fmt --all -- --check                       -> clean (exit 0)
cargo clippy --all-targets --all-features -D warnings -> exit 0, no warnings
cargo test --lib --all-features                  -> 1447 passed; 0 failed (+40 new socketio)
cargo test --doc --all-features                  -> 168 passed; 0 failed
cargo test --test integration_tests --all-features -> 22 passed; 0 failed
cargo build --target wasm32-unknown-unknown --no-default-features --features socketio,wasm -> Finished (exit 0)
cargo build --target wasm32-unknown-unknown --no-default-features --features auth,wasm     -> exit 0 (no regression)
cargo build --no-default-features --features socketio                                      -> exit 0
```

## Test plan

- [x] Byte-exact `authMessage` EVENT framing (`42["authMessage",{...}]`, default ns, round-trips)
- [x] Byte-exact `{eventName,data}` envelope encode/decode + round-trip
- [x] Inbound `run_dispatch` routes `authMessage` EVENT to the registered callback
- [x] Inbound `run_dispatch` auto-replies `Pong` to Engine.IO `Ping`
- [x] wasm32 build with `socketio` (proves zero substrate coupling)
- [x] No regression to `auth`-only wasm32 build

🤖 Generated with [Claude Code](https://claude.com/claude-code)