### PR TITLE
release: v0.3.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bsv-rs"
-version = "0.3.12"
+version = "0.3.13"
 edition = "2021"
 description = "BSV blockchain SDK for Rust - primitives, script, transactions, and more"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Version bump for the BRC-104 transport timeout fix (#5). Publishes to crates.io.